### PR TITLE
Allow NULL for several fields in 'vehicle.dtd'

### DIFF
--- a/Vehicle.dtd
+++ b/Vehicle.dtd
@@ -32,13 +32,13 @@
 			"descrption": "Internal name of the vehicle"
 		},
 		"vehicle_reg_state": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_reg_state",
 			"title": "Vehicle registration state",
 			"descrption": "A state where vehicle was registered"
 		},
 		"vehicle_reg_state_id": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_reg_state_id",
 			"title": "Vehicle registration state ID",
 			"descrption": "An ID of the state, where vehicle was registered"
@@ -50,37 +50,37 @@
 			"descrption": "A country where vehicle was registered"
 		},
 		"vehicle_reg_country_id": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_reg_country_id",
 			"title": "Vehicle registration country ID",
 			"descrption": "An ID of the country, where vehicle was registered"
 		},
 		"vehicle_license_plate": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_license_plate",
 			"title": "Vehicle license plate",
 			"descrption": "A license plate of the vehicle"
 		},
 		"vehicle_make": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_make",
 			"title": "Vehicle make",
 			"descrption": "Vehicle maker brend"
 		},
 		"vehicle_model_year": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_model_year",
 			"title": "Vehicle model year",
 			"descrption": "A year of the vehicle model"
 		},
 		"vehicle_model": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_model",
 			"title": "Vehicle model",
 			"descrption": "A model of the vehicle"
 		},
 		"vehicle_year_acquired": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_year_acquired",
 			"title": "Vehicle acquired year",
 			"descrption": "A year the vehicle was acquired"
@@ -106,37 +106,37 @@
 			"descrption": "An end date of the license"
 		},
 		"vehicle_axle_count": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_axle_count",
 			"title": "Vehicle axle count",
 			"descrption": "A number of the vecile's axles"
 		},
 		"mpg_city": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "mpg_city",
 			"title": "MPG city",
 			"descrption": "Miles per gallon in the city area"
 		},
 		"mpg_highway": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "mpg_highway",
 			"title": "MPG highway",
 			"descrption": "Miles per gallon in the highway area"
 		},
 		"fuel_type": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "fuel_type",
 			"title": "Fuel type",
 			"descrption": "A type of the fuel"
 		},
 		"height_inches": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "height_inches",
 			"title": "Height inches",
 			"descrption": "A height of the vehicle in the inches."
 		},
 		"weight_lb": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "weight_lb",
 			"title": "Weight lbs",
 			"descrption": "A weight of the vehicle in the pounds."

--- a/Vehicle.dtd
+++ b/Vehicle.dtd
@@ -44,7 +44,7 @@
 			"descrption": "An ID of the state, where vehicle was registered"
 		},
 		"vehicle_reg_country": {
-			"type": "string",
+			"type": ["string", "null"],
 			"name": "vehicle_reg_country",
 			"title": "Vehicle registration country",
 			"descrption": "A country where vehicle was registered"
@@ -86,20 +86,20 @@
 			"descrption": "A year the vehicle was acquired"
 		},
 		"vehicle_cost_new": {
-			"type": "number",
+			"type": ["number", "null"],
 			"name": "vehicle_cost_new",
 			"title": "Vehicle cost new",
 			"descrption": "A cost f the new vehicle"
 		},
 		"license_start_date": {
-			"type": "string",
+			"type": ["string", "null"],
 			"format": "date-time",
 			"name": "license_start_date",
 			"title": "License start date",
 			"descrption": "A start date of the license"
 		},
 		"license_end_date": {
-			"type": "string",
+			"type": ["string", "null"],
 			"format": "date-time",
 			"name": "license_end_date",
 			"title": "License end date",


### PR DESCRIPTION
I have tested the schema on data, returned by this URL: https://www.route4me.com/api/vehicles/view_vehicles.php?api_key=11111111111111111111111111111111

Fields:

* vehicle_reg_country
* vehicle_cost_new
* license_start_date
* license_end_date
* vehicle_reg_state
* vehicle_reg_state_id
* vehicle_reg_country_id
* vehicle_license_plate
* vehicle_make
* vehicle_model_year
* vehicle_model
* vehicle_year_acquired
* vehicle_axle_count
* mpg_city
* mpg_highway
* fuel_type
* height_inches
* weight_lb